### PR TITLE
Fix "The connection string name is missing for the MySqlSiteMapProvider"

### DIFF
--- a/UI.Web/Web.config
+++ b/UI.Web/Web.config
@@ -7,6 +7,11 @@
   <system.web>
     <compilation debug="true" targetFramework="4.7.2" />
     <httpRuntime targetFramework="4.7.2" />
+	<siteMap>
+	  <providers>
+		<remove name="MySqlSiteMapProvider" />	
+      </providers>
+	</siteMap>
   </system.web>
   <system.codedom>
     <compilers>


### PR DESCRIPTION
Este error ocurre cuando está instalado el Conector .NET de MySQL, el cual modifica el archivo machine.config de la version de .NET Framework